### PR TITLE
FIx audio duration for Iphone

### DIFF
--- a/main.py
+++ b/main.py
@@ -30,7 +30,13 @@ def task(link):
     with youtube_dl.YoutubeDL(options) as ydl:
         ydl.download([video_info['webpage_url']])
     audio = open('C:\\Users\\PC\\PycharmProjects\\myfirstbot\\' + format(filename), 'rb')
-    bot.send_audio(link.chat.id, audio)
+
+    # Grab known info from metadata
+    duration = video_info["duration"]
+    title = video_info.get("track", None)
+    artist = video_info.get("artist", None)
+    # Send the audio in response
+    bot.send_audio(link.chat.id, audio, duration=duration, title=title, performer=artist)
     audio.close()
     os.remove("C:\\Users\\PC\\PycharmProjects\\myfirstbot\\" + format(filename))
 

--- a/main.py
+++ b/main.py
@@ -1,7 +1,9 @@
 import telebot
 import youtube_dl
 import os
-bot = telebot.TeleBot("token", parse_mode=None)
+import sys
+import re
+bot = telebot.TeleBot(sys.argv[1], parse_mode=None)
 
 
 @bot.message_handler(commands=['start', 'help'])
@@ -14,23 +16,31 @@ def send_welcome(message):
     sent = bot.send_message(message.chat.id, "send me your link)")
     bot.register_next_step_handler(sent, task)
 
+def get_valid_filename(s):
+    s = str(s).strip().replace(' ', '_')
+    return re.sub(r'(?u)[^-\w.]', '', s)
 
 def task(link):
     video_url = link.text
     video_info = youtube_dl.YoutubeDL().extract_info(
         url=video_url, download=False
     )
-    filename = f"{video_info['title']}.mp3"
+    filename_tmp = f"{get_valid_filename(video_info['title'])}.dat"
+    filename =  f"{get_valid_filename(video_info['title'])}.mp3"
     options = {
         'format': 'bestaudio/best',
         'keepvideo': False,
-        'outtmpl': filename,
+        'outtmpl': filename_tmp,
+        'postprocessors': [{
+        'key': 'FFmpegExtractAudio',
+        'preferredcodec': 'mp3',
+        'preferredquality': '320',
+    }],
     }
-
     with youtube_dl.YoutubeDL(options) as ydl:
         ydl.download([video_info['webpage_url']])
-    audio = open('C:\\Users\\PC\\PycharmProjects\\myfirstbot\\' + format(filename), 'rb')
-
+    audio = open(filename, 'rb')
+    
     # Grab known info from metadata
     duration = video_info["duration"]
     title = video_info.get("track", None)
@@ -38,7 +48,7 @@ def task(link):
     # Send the audio in response
     bot.send_audio(link.chat.id, audio, duration=duration, title=title, performer=artist)
     audio.close()
-    os.remove("C:\\Users\\PC\\PycharmProjects\\myfirstbot\\" + format(filename))
+    os.remove(filename)
 
 
 bot.polling(none_stop=False, interval=0, timeout=20)


### PR DESCRIPTION
Telegram on Iphone is not playing full audio if duration is not specified, or wrong file format provided.
Now we do conversion to mp3 by postprocessing.
Also removed custom file path
Also added parametric token for daemon
Also added better handling for filenames
